### PR TITLE
Update API port change in ApiServerVerticle

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The Keycloak host and port, along with the client IDs and client secret informat
 4. Modify the `docker-compose.yml` file to map the config file you just created
 5. Start the server in production (prod) or development (dev) mode using docker-compose 
    ` docker-compose up prod `
-6. The server will be up in Port 8443
+6. The server will be up on port **8080**. To change the port, add `httpPort:<desired_port_number>` to the config in the `ApiServerVerticle` module. See [configs/config-example.json](configs/config-example.json) for an example.
 
 ### Maven based
 1. Install java 11 and maven
@@ -99,7 +99,7 @@ export LOG_LEVEL=INFO
 ```
 3. Use the maven exec plugin based starter to start the server 
    `mvn clean compile exec:java@aaa-server`
-4. The server will be up in Port 8443.
+4. The server will be up on port **8080**. To change the port, add `httpPort:<desired_port_number>` to the config in the `ApiServerVerticle` module. See [configs/config-example.json](configs/config-example.json) for an example.
 
 ### JAR based
 1. Install java 11 and maven

--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -95,7 +95,6 @@
     },
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
-      "httpPort": 8443,
       "verticleInstances": 1,
       "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
       "poolSize": "5",

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -96,7 +96,6 @@
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
       "verticleInstances": 1,
-      "httpPort": 8443,
       "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -96,7 +96,6 @@
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
       "verticleInstances": 1,
-      "httpPort": 8443,
       "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,

--- a/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
@@ -69,10 +69,9 @@ public class ApiServerVerticle extends AbstractVerticle {
   private static final Logger LOGGER = LogManager.getLogger(ApiServerVerticle.class);
   private HttpServer server;
   private Router router;
-  private int port = 8443;
-  private boolean isSSL;
-  private String keystorePath;
-  private String keystorePassword;
+  private int port;
+  private String jwtKeystorePath;
+  private String jwtKeystorePassword;
 
   private String databaseIP;
   private int databasePort;
@@ -105,7 +104,7 @@ public class ApiServerVerticle extends AbstractVerticle {
   /**
    * This method is used to start the Verticle. It deploys a verticle in a cluster, reads the
    * configuration, obtains a proxy for the Event bus services exposed through service discovery,
-   * start an HTTP server at port 8443
+   * start an HTTP server at port 8080 unless another port is supplied in the configuration.
    *
    * @throws Exception which is a startup exception TODO Need to add documentation for all the
    *
@@ -125,7 +124,8 @@ public class ApiServerVerticle extends AbstractVerticle {
     serverTimeout = Long.parseLong(config().getString(SERVER_TIMEOUT_MS));
     corsRegex = config().getString(CORS_REGEX);
     authServerDomain = config().getString(AUTHSERVER_DOMAIN);
-
+    jwtKeystorePath = config().getString(KEYSTORE_PATH);
+    jwtKeystorePassword = config().getString(KEYSTPRE_PASSWORD);
 
     /* Set Connection Object and schema */
     if (connectOptions == null) {
@@ -339,22 +339,16 @@ public class ApiServerVerticle extends AbstractVerticle {
                 .setStatusCode(404).end(JSON_NOT_FOUND);
               });
 
-          LOGGER.info("starting server");
-          HttpServerOptions serverOptions = new HttpServerOptions();
+              HttpServerOptions serverOptions = new HttpServerOptions();
+              LOGGER.debug("Info: Starting HTTP server");
 
-            LOGGER.debug("Info: Starting HTTP server");
-
-            /* Setup the HTTP server properties, APIs and port. */
-
-            serverOptions.setSsl(false);
-            /*
-             * Default port when ssl is disabled is 8080. If set through config, then that value is
-             * taken
-             */
-            port = config().getInteger("httpPort") == null ? 8080 : config().getInteger("httpPort");
-            LOGGER.info("Info: Starting HTTP server at port " + port);
-
-
+              /*
+               * Setup the HTTP server properties, APIs and port. Default port is 8080. If set through
+               * config, then that value is taken
+               */
+              serverOptions.setSsl(false);
+              port = config().getInteger("httpPort") == null ? 8080 : config().getInteger("httpPort");
+              LOGGER.info("Info: Starting HTTP server at port " + port);
 
               serverOptions.setCompressionSupported(true).setCompressionLevel(5);
               server = vertx.createHttpServer(serverOptions);
@@ -861,7 +855,7 @@ public class ApiServerVerticle extends AbstractVerticle {
    */
   private void pubCertHandler(RoutingContext context) {
 
-    JksOptions options = new JksOptions().setPath(keystorePath).setPassword(keystorePassword);
+    JksOptions options = new JksOptions().setPath(jwtKeystorePath).setPassword(jwtKeystorePassword);
     try {
       KeyStore ks = options.loadKeyStore(vertx);
       if (ks.containsAlias(KS_ALIAS)) {


### PR DESCRIPTION
- Remove references to port 8443
- Re-add keystore options - this is needed for the `/auth/v1/cert` endpoint
- Rename keystore variabled to `jwtKeystore` to make it clearer
- Fix indents